### PR TITLE
img responsive on modal shopingcart

### DIFF
--- a/modules/ps_shoppingcart/modal.tpl
+++ b/modules/ps_shoppingcart/modal.tpl
@@ -27,7 +27,7 @@
                   <img
                     src="{$urls.no_picture_image.bySize.medium_default.url}"
                     loading="lazy"
-                    class="product-image"
+                    class="img-fluid product-image"
                   />
                 {/if}
               </div>


### PR DESCRIPTION
On no img product, when added to car, img has no responsive class, so its out of div element.
![imagen](https://user-images.githubusercontent.com/10741347/170701895-eec98135-0a96-4e8e-8a0a-aa13ac931035.png)
FIXED:
![imagen](https://user-images.githubusercontent.com/10741347/170701988-902a995a-d997-4321-a872-4d32d9a7625c.png)
